### PR TITLE
Update README to document Swift 6.1 alignment

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@ The official Observation framework in Swift Toolchain doesn't ship with `package
 
 2. **OpenObservation approach** (this project): Reimplement Observation framework, allowing OpenSwiftUI to import it via `@_spi(OpenSwiftUI)`
 
+## Implementation Status
+
+The current implementation is aligned with Swift's **release/6.1 branch** implementation of the Observation framework.
+
 ## Features
 
 - Full Observation framework implementation


### PR DESCRIPTION
## Summary
- Added Implementation Status section to README
- Documents that the current codebase aligns with Swift's release/6.1 branch

## Test plan
- [x] README renders correctly
- [x] No code changes, documentation only